### PR TITLE
Sideband and signal regions

### DIFF
--- a/RDFAnalysis/RDF_MC_Kll_jobs.cpp
+++ b/RDFAnalysis/RDF_MC_Kll_jobs.cpp
@@ -122,35 +122,38 @@ inputFileList.push_back(base + "BuToKJpsi_ToMuMu_probefilter_SoftQCDnonD_TuneCP5
      .Define("KEE_k_eta_All", "BToKEE_fit_k_eta")
      .Define("KEE_k_phi_All", "BToKEE_fit_k_phi")
      .Define("KEE_k_pt_All", "BToKEE_fit_k_pt")
-     .Define("KEE_k_dz_All", "(ROOT::VecOps::RVec<float>) Take(ProbeTracks_dz, BToKEE_kIdx)")
-     .Define("KEE_k_dzE_All", "(ROOT::VecOps::RVec<float>) Take(ProbeTracks_dzS, BToKEE_kIdx)")
-     .Define("KEE_k_dxy_All", "(ROOT::VecOps::RVec<float>) Take(ProbeTracks_dxy, BToKEE_kIdx)")
-     .Define("KEE_k_dxyE_All", "(ROOT::VecOps::RVec<float>) Take(ProbeTracks_dxyS, BToKEE_kIdx)")
-     .Define("KEE_k_isPck_All", "(ROOT::VecOps::RVec<unsigned int>) Take(ProbeTracks_isPacked, BToKEE_kIdx)")
+     .Define("KEE_k_dz_All", "Take(ProbeTracks_dz, BToKEE_kIdx)")
+     .Define("KEE_k_dzE_All", "Take(ProbeTracks_dzS, BToKEE_kIdx)")
+     .Define("KEE_k_dxy_All", "Take(ProbeTracks_dxy, BToKEE_kIdx)")
+     .Define("KEE_k_dxyE_All", "Take(ProbeTracks_dxyS, BToKEE_kIdx)")
+     .Define("KEE_k_isPck_All", "Take(ProbeTracks_isPacked, BToKEE_kIdx)")//int
      .Define("e1_eta_All", "BToKEE_fit_l1_eta")
      .Define("e2_eta_All", "BToKEE_fit_l2_eta")
      .Define("e1_phi_All", "BToKEE_fit_l1_phi")
      .Define("e2_phi_All", "BToKEE_fit_l2_phi")
      .Define("e1_pt_All", "BToKEE_fit_l1_pt")
      .Define("e2_pt_All", "BToKEE_fit_l2_pt")
-     .Define("e1_dz_All", "(ROOT::VecOps::RVec<float>) Take(Electron_dz, BToKEE_l1Idx)")
-     .Define("e2_dz_All", "(ROOT::VecOps::RVec<float>) Take(Electron_dz, BToKEE_l2Idx)")
-     .Define("e1_dzE_All", "(ROOT::VecOps::RVec<float>) Take(Electron_dzErr, BToKEE_l1Idx)")
-     .Define("e2_dzE_All", "(ROOT::VecOps::RVec<float>) Take(Electron_dzErr, BToKEE_l2Idx)")
-     .Define("e1_dxy_All", "(ROOT::VecOps::RVec<float>) Take(Electron_dxy, BToKEE_l1Idx)")
-     .Define("e2_dxy_All", "(ROOT::VecOps::RVec<float>) Take(Electron_dxy, BToKEE_l2Idx)")
-     .Define("e1_dxyE_All", "(ROOT::VecOps::RVec<float>) Take(Electron_dxyErr, BToKEE_l1Idx)")
-     .Define("e2_dxyE_All", "(ROOT::VecOps::RVec<float>) Take(Electron_dxyErr, BToKEE_l2Idx)")
-     .Define("e1_isConvVeto_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_convVeto, BToKEE_l1Idx)")
-     .Define("e2_isConvVeto_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_convVeto, BToKEE_l2Idx)")
-     .Define("e1_seedID_All", "(ROOT::VecOps::RVec<float>) Take(Electron_unBiased, BToKEE_l1Idx)")
-     .Define("e2_seedID_All", "(ROOT::VecOps::RVec<float>) Take(Electron_unBiased, BToKEE_l2Idx)")
-     .Define("e1_mvaID_All", "(ROOT::VecOps::RVec<float>) Take(Electron_mvaId, BToKEE_l1Idx)")
-     .Define("e2_mvaID_All", "(ROOT::VecOps::RVec<float>) Take(Electron_mvaId, BToKEE_l2Idx)")
-     .Define("e1_isPF_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_isPF, BToKEE_l1Idx)")
-     .Define("e2_isPF_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_isPF, BToKEE_l2Idx)")
-     .Define("e1_isPFoverlap_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_isPFoverlap, BToKEE_l1Idx)")
-     .Define("e2_isPFoverlap_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_isPFoverlap, BToKEE_l2Idx)")    
+     .Define("e1_dz_All", "Take(Electron_dz, BToKEE_l1Idx)")
+     .Define("e2_dz_All", "Take(Electron_dz, BToKEE_l2Idx)")
+     .Define("e1_dzE_All", "Take(Electron_dzErr, BToKEE_l1Idx)")
+     .Define("e2_dzE_All", "Take(Electron_dzErr, BToKEE_l2Idx)")
+     .Define("e1_dxy_All", "Take(Electron_dxy, BToKEE_l1Idx)")
+     .Define("e2_dxy_All", "Take(Electron_dxy, BToKEE_l2Idx)")
+     .Define("e1_dxyE_All", "Take(Electron_dxyErr, BToKEE_l1Idx)")
+     .Define("e2_dxyE_All", "Take(Electron_dxyErr, BToKEE_l2Idx)")
+     .Define("e1_isConvVeto_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_convVeto, BToKEE_l1Idx)")//bool
+     .Define("e2_isConvVeto_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_convVeto, BToKEE_l2Idx)")//bool
+     .Define("e1_seedID_All", "Take(Electron_unBiased, BToKEE_l1Idx)")
+     .Define("e2_seedID_All", "Take(Electron_unBiased, BToKEE_l2Idx)")
+     .Define("e1_mvaID_All", "Take(Electron_mvaId, BToKEE_l1Idx)")
+     .Define("e2_mvaID_All", "Take(Electron_mvaId, BToKEE_l2Idx)")
+     .Define("e1_isPF_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_isPF, BToKEE_l1Idx)")//bool
+     .Define("e2_isPF_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_isPF, BToKEE_l2Idx)")//bool
+     .Define("e1_isLowPt_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_isLowPt, BToKEE_l1Idx)")//bool
+     .Define("e2_isLowPt_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_isLowPt, BToKEE_l2Idx)")//bool     
+     .Define("e1_isPFoverlap_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_isPFoverlap, BToKEE_l1Idx)")//bool
+     .Define("e2_isPFoverlap_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_isPFoverlap, BToKEE_l2Idx)")//bool
+     .Define("Idx_sel", bkgSB, { "nBToKEE_All", "e1_isPFoverlap_All", "e2_isPFoverlap_All",  "KEE_fit_mass_All"} )
     
      .Define("nBToKMM_All", "nBToKMuMu")
      .Define("KMM_fit_mass_All", "BToKMuMu_fit_mass")
@@ -166,36 +169,36 @@ inputFileList.push_back(base + "BuToKJpsi_ToMuMu_probefilter_SoftQCDnonD_TuneCP5
      .Define("KMM_k_eta_All", "BToKMuMu_fit_k_eta")
      .Define("KMM_k_phi_All", "BToKMuMu_fit_k_phi")
      .Define("KMM_k_pt_All", "BToKMuMu_fit_k_pt")
-     .Define("KMM_k_dz_All", "(ROOT::VecOps::RVec<float>) Take(ProbeTracks_dz, BToKMuMu_kIdx)")
-     .Define("KMM_dzE_All", "(ROOT::VecOps::RVec<float>) Take(ProbeTracks_dzS, BToKMuMu_kIdx)")
-     .Define("KMM_k_dxy_All", "(ROOT::VecOps::RVec<float>) Take(ProbeTracks_dxy, BToKMuMu_kIdx)")
-     .Define("KMM_k_dxyE_All", "(ROOT::VecOps::RVec<float>) Take(ProbeTracks_dxyS, BToKMuMu_kIdx)")
-     .Define("KMM_k_isPck_All", "(ROOT::VecOps::RVec<unsigned int>) Take(ProbeTracks_isPacked, BToKMuMu_kIdx)")    
+     .Define("KMM_k_dz_All", "Take(ProbeTracks_dz, BToKMuMu_kIdx)")
+     .Define("KMM_dzE_All", "Take(ProbeTracks_dzS, BToKMuMu_kIdx)")
+     .Define("KMM_k_dxy_All", "Take(ProbeTracks_dxy, BToKMuMu_kIdx)")
+     .Define("KMM_k_dxyE_All", "Take(ProbeTracks_dxyS, BToKMuMu_kIdx)")
+     .Define("KMM_k_isPck_All", "Take(ProbeTracks_isPacked, BToKMuMu_kIdx)")//int  
      .Define("m1_eta_All", "BToKMuMu_fit_l1_eta")
      .Define("m2_eta_All", "BToKMuMu_fit_l2_eta")
      .Define("m1_phi_All", "BToKMuMu_fit_l1_phi")
      .Define("m2_phi_All", "BToKMuMu_fit_l2_phi")
      .Define("m1_pt_All", "BToKMuMu_fit_l1_pt")
      .Define("m2_pt_All", "BToKMuMu_fit_l2_pt")
-     .Define("m1_dz_All", "(ROOT::VecOps::RVec<float>) Take(Muon_dz, BToKMuMu_l1Idx)")
-     .Define("m2_dz_All", "(ROOT::VecOps::RVec<float>) Take(Muon_dz, BToKMuMu_l2Idx)")
-     .Define("m1_dzE_All", "(ROOT::VecOps::RVec<float>) Take(Muon_dzErr, BToKMuMu_l1Idx)")
-     .Define("m2_dzE_All", "(ROOT::VecOps::RVec<float>) Take(Muon_dzErr, BToKMuMu_l2Idx)")
-     .Define("m1_dxy_All", "(ROOT::VecOps::RVec<float>) Take(Muon_dxy, BToKMuMu_l1Idx)")
-     .Define("m2_dxy_All", "(ROOT::VecOps::RVec<float>) Take(Muon_dxy, BToKMuMu_l2Idx)")
-     .Define("m1_dxyE_All", "(ROOT::VecOps::RVec<float>) Take(Muon_dxyErr, BToKMuMu_l1Idx)")
-     .Define("m2_dxyE_All", "(ROOT::VecOps::RVec<float>) Take(Muon_dxyErr, BToKMuMu_l2Idx)")
-     .Define("m1_mvaID_All", "(ROOT::VecOps::RVec<float>) Take(Muon_mvaId, BToKMuMu_l1Idx)")
-     .Define("m2_mvaID_All", "(ROOT::VecOps::RVec<float>) Take(Muon_mvaId, BToKMuMu_l2Idx)")
-     .Define("m1_isPF_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Muon_isPFcand, BToKMuMu_l1Idx)")
-     .Define("m2_isPF_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Muon_isPFcand, BToKMuMu_l2Idx)")
-     .Define("m1_isTriggering_All", "Take(Muon_isTriggering, BToKMuMu_l1Idx)")
-     .Define("m2_isTriggering_All", "Take(Muon_isTriggering, BToKMuMu_l2Idx)")
+     .Define("m1_dz_All", "Take(Muon_dz, BToKMuMu_l1Idx)")
+     .Define("m2_dz_All", "Take(Muon_dz, BToKMuMu_l2Idx)")
+     .Define("m1_dzE_All", "Take(Muon_dzErr, BToKMuMu_l1Idx)")
+     .Define("m2_dzE_All", "Take(Muon_dzErr, BToKMuMu_l2Idx)")
+     .Define("m1_dxy_All", "Take(Muon_dxy, BToKMuMu_l1Idx)")
+     .Define("m2_dxy_All", "Take(Muon_dxy, BToKMuMu_l2Idx)")
+     .Define("m1_dxyE_All", "Take(Muon_dxyErr, BToKMuMu_l1Idx)")
+     .Define("m2_dxyE_All", "Take(Muon_dxyErr, BToKMuMu_l2Idx)")
+     .Define("m1_mvaID_All", "Take(Muon_mvaId, BToKMuMu_l1Idx)")
+     .Define("m2_mvaID_All", "Take(Muon_mvaId, BToKMuMu_l2Idx)")
+     .Define("m1_isPF_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Muon_isPFcand, BToKMuMu_l1Idx)")//bool
+     .Define("m2_isPF_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Muon_isPFcand, BToKMuMu_l2Idx)")//bool
+     .Define("m1_isTriggering_All", "Take(Muon_isTriggering, BToKMuMu_l1Idx)")//int
+     .Define("m2_isTriggering_All", "Take(Muon_isTriggering, BToKMuMu_l2Idx)")//int
      .Define("KMM_nExtraTrg_All", "(nTriggerMuon - m1_isTriggering_All - m2_isTriggering_All)");
   
     std::cout << " totN start = " << *(d.Count())
     	      << " valid KEE triplets = " << *(n.Filter("nBToKEE_All > 0").Count())
-    	      << " valid KMM triplets = " << *(n.Filter("nBToKMuMu > 0").Count()) << std::endl;
+    	      << " valid KMM triplets = " << *(n.Filter("nBToKMM_All > 0").Count()) << std::endl;
   }
   
   
@@ -216,35 +219,37 @@ inputFileList.push_back(base + "BuToKJpsi_ToMuMu_probefilter_SoftQCDnonD_TuneCP5
      .Define("KEE_k_eta_All", "BToKEE_fit_k_eta")
      .Define("KEE_k_phi_All", "BToKEE_fit_k_phi")
      .Define("KEE_k_pt_All", "BToKEE_fit_k_pt")
-     .Define("KEE_k_dz_All", "(ROOT::VecOps::RVec<float>) Take(ProbeTracks_dz, BToKEE_kIdx)")
-     .Define("KEE_k_dzE_All", "(ROOT::VecOps::RVec<float>) Take(ProbeTracks_dzS, BToKEE_kIdx)")
-     .Define("KEE_k_dxy_All", "(ROOT::VecOps::RVec<float>) Take(ProbeTracks_dxy, BToKEE_kIdx)")
-     .Define("KEE_k_dxyE_All", "(ROOT::VecOps::RVec<float>) Take(ProbeTracks_dxyS, BToKEE_kIdx)")
-     .Define("KEE_k_isPck_All", "(ROOT::VecOps::RVec<unsigned int>) Take(ProbeTracks_isPacked, BToKEE_kIdx)")
+     .Define("KEE_k_dz_All", "Take(ProbeTracks_dz, BToKEE_kIdx)")
+     .Define("KEE_k_dzE_All", "Take(ProbeTracks_dzS, BToKEE_kIdx)")
+     .Define("KEE_k_dxy_All", "Take(ProbeTracks_dxy, BToKEE_kIdx)")
+     .Define("KEE_k_dxyE_All", "Take(ProbeTracks_dxyS, BToKEE_kIdx)")
+     .Define("KEE_k_isPck_All", "Take(ProbeTracks_isPacked, BToKEE_kIdx)")//int
      .Define("e1_eta_All", "BToKEE_fit_l1_eta")
      .Define("e2_eta_All", "BToKEE_fit_l2_eta")
      .Define("e1_phi_All", "BToKEE_fit_l1_phi")
      .Define("e2_phi_All", "BToKEE_fit_l2_phi")
      .Define("e1_pt_All", "BToKEE_fit_l1_pt")
      .Define("e2_pt_All", "BToKEE_fit_l2_pt")
-     .Define("e1_dz_All", "(ROOT::VecOps::RVec<float>) Take(Electron_dz, BToKEE_l1Idx)")
-     .Define("e2_dz_All", "(ROOT::VecOps::RVec<float>) Take(Electron_dz, BToKEE_l2Idx)")
-     .Define("e1_dzE_All", "(ROOT::VecOps::RVec<float>) Take(Electron_dzErr, BToKEE_l1Idx)")
-     .Define("e2_dzE_All", "(ROOT::VecOps::RVec<float>) Take(Electron_dzErr, BToKEE_l2Idx)")
-     .Define("e1_dxy_All", "(ROOT::VecOps::RVec<float>) Take(Electron_dxy, BToKEE_l1Idx)")
-     .Define("e2_dxy_All", "(ROOT::VecOps::RVec<float>) Take(Electron_dxy, BToKEE_l2Idx)")
-     .Define("e1_dxyE_All", "(ROOT::VecOps::RVec<float>) Take(Electron_dxyErr, BToKEE_l1Idx)")
-     .Define("e2_dxyE_All", "(ROOT::VecOps::RVec<float>) Take(Electron_dxyErr, BToKEE_l2Idx)")
-     .Define("e1_isConvVeto_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_convVeto, BToKEE_l1Idx)")
-     .Define("e2_isConvVeto_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_convVeto, BToKEE_l2Idx)")
-     .Define("e1_seedID_All", "(ROOT::VecOps::RVec<float>) Take(Electron_unBiased, BToKEE_l1Idx)")
-     .Define("e2_seedID_All", "(ROOT::VecOps::RVec<float>) Take(Electron_unBiased, BToKEE_l2Idx)")
-     .Define("e1_mvaID_All", "(ROOT::VecOps::RVec<float>) Take(Electron_mvaId, BToKEE_l1Idx)")
-     .Define("e2_mvaID_All", "(ROOT::VecOps::RVec<float>) Take(Electron_mvaId, BToKEE_l2Idx)")
-     .Define("e1_isPF_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_isPF, BToKEE_l1Idx)")
-     .Define("e2_isPF_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_isPF, BToKEE_l2Idx)")
-     .Define("e1_isPFoverlap_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_isPFoverlap, BToKEE_l1Idx)")
-     .Define("e2_isPFoverlap_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_isPFoverlap, BToKEE_l2Idx)");
+     .Define("e1_dz_All", "Take(Electron_dz, BToKEE_l1Idx)")
+     .Define("e2_dz_All", "Take(Electron_dz, BToKEE_l2Idx)")
+     .Define("e1_dzE_All", "Take(Electron_dzErr, BToKEE_l1Idx)")
+     .Define("e2_dzE_All", "Take(Electron_dzErr, BToKEE_l2Idx)")
+     .Define("e1_dxy_All", "Take(Electron_dxy, BToKEE_l1Idx)")
+     .Define("e2_dxy_All", "Take(Electron_dxy, BToKEE_l2Idx)")
+     .Define("e1_dxyE_All", "Take(Electron_dxyErr, BToKEE_l1Idx)")
+     .Define("e2_dxyE_All", "Take(Electron_dxyErr, BToKEE_l2Idx)")
+     .Define("e1_isConvVeto_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_convVeto, BToKEE_l1Idx)")//bool
+     .Define("e2_isConvVeto_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_convVeto, BToKEE_l2Idx)")//bool
+     .Define("e1_seedID_All", "Take(Electron_unBiased, BToKEE_l1Idx)")
+     .Define("e2_seedID_All", "Take(Electron_unBiased, BToKEE_l2Idx)")
+     .Define("e1_mvaID_All", "Take(Electron_mvaId, BToKEE_l1Idx)")
+     .Define("e2_mvaID_All", "Take(Electron_mvaId, BToKEE_l2Idx)")
+     .Define("e1_isPF_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_isPF, BToKEE_l1Idx)")//bool
+     .Define("e2_isPF_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_isPF, BToKEE_l2Idx)")//bool
+     .Define("e1_isLowPt_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_isLowPt, BToKEE_l1Idx)")//bool
+     .Define("e2_isLowPt_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_isLowPt, BToKEE_l2Idx)")//bool     
+     .Define("e1_isPFoverlap_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_isPFoverlap, BToKEE_l1Idx)")//bool
+     .Define("e2_isPFoverlap_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Electron_isPFoverlap, BToKEE_l2Idx)");//bool
 
     std::cout << " totN start = " << *(d.Count())
 	      << " valid KEE triplets = " << *(n.Filter("nBToKEE_All > 0").Count());
@@ -268,31 +273,31 @@ inputFileList.push_back(base + "BuToKJpsi_ToMuMu_probefilter_SoftQCDnonD_TuneCP5
      .Define("KMM_k_eta_All", "BToKMuMu_fit_k_eta")
      .Define("KMM_k_phi_All", "BToKMuMu_fit_k_phi")
      .Define("KMM_k_pt_All", "BToKMuMu_fit_k_pt")
-     .Define("KMM_k_dz_All", "(ROOT::VecOps::RVec<float>) Take(ProbeTracks_dz, BToKMuMu_kIdx)")
-     .Define("KMM_dzE_All", "(ROOT::VecOps::RVec<float>) Take(ProbeTracks_dzS, BToKMuMu_kIdx)")
-     .Define("KMM_k_dxy_All", "(ROOT::VecOps::RVec<float>) Take(ProbeTracks_dxy, BToKMuMu_kIdx)")
-     .Define("KMM_k_dxyE_All", "(ROOT::VecOps::RVec<float>) Take(ProbeTracks_dxyS, BToKMuMu_kIdx)")
-     .Define("KMM_k_isPck_All", "(ROOT::VecOps::RVec<unsigned int>) Take(ProbeTracks_isPacked, BToKMuMu_kIdx)")    
+     .Define("KMM_k_dz_All", "Take(ProbeTracks_dz, BToKMuMu_kIdx)")
+     .Define("KMM_dzE_All", "Take(ProbeTracks_dzS, BToKMuMu_kIdx)")
+     .Define("KMM_k_dxy_All", "Take(ProbeTracks_dxy, BToKMuMu_kIdx)")
+     .Define("KMM_k_dxyE_All", "Take(ProbeTracks_dxyS, BToKMuMu_kIdx)")
+     .Define("KMM_k_isPck_All", "Take(ProbeTracks_isPacked, BToKMuMu_kIdx)")//int  
      .Define("m1_eta_All", "BToKMuMu_fit_l1_eta")
      .Define("m2_eta_All", "BToKMuMu_fit_l2_eta")
      .Define("m1_phi_All", "BToKMuMu_fit_l1_phi")
      .Define("m2_phi_All", "BToKMuMu_fit_l2_phi")
      .Define("m1_pt_All", "BToKMuMu_fit_l1_pt")
      .Define("m2_pt_All", "BToKMuMu_fit_l2_pt")
-     .Define("m1_dz_All", "(ROOT::VecOps::RVec<float>) Take(Muon_dz, BToKMuMu_l1Idx)")
-     .Define("m2_dz_All", "(ROOT::VecOps::RVec<float>) Take(Muon_dz, BToKMuMu_l2Idx)")
-     .Define("m1_dzE_All", "(ROOT::VecOps::RVec<float>) Take(Muon_dzErr, BToKMuMu_l1Idx)")
-     .Define("m2_dzE_All", "(ROOT::VecOps::RVec<float>) Take(Muon_dzErr, BToKMuMu_l2Idx)")
-     .Define("m1_dxy_All", "(ROOT::VecOps::RVec<float>) Take(Muon_dxy, BToKMuMu_l1Idx)")
-     .Define("m2_dxy_All", "(ROOT::VecOps::RVec<float>) Take(Muon_dxy, BToKMuMu_l2Idx)")
-     .Define("m1_dxyE_All", "(ROOT::VecOps::RVec<float>) Take(Muon_dxyErr, BToKMuMu_l1Idx)")
-     .Define("m2_dxyE_All", "(ROOT::VecOps::RVec<float>) Take(Muon_dxyErr, BToKMuMu_l2Idx)")
-     .Define("m1_mvaID_All", "(ROOT::VecOps::RVec<float>) Take(Muon_mvaId, BToKMuMu_l1Idx)")
-     .Define("m2_mvaID_All", "(ROOT::VecOps::RVec<float>) Take(Muon_mvaId, BToKMuMu_l2Idx)")
-     .Define("m1_isPF_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Muon_isPFcand, BToKMuMu_l1Idx)")
-     .Define("m2_isPF_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Muon_isPFcand, BToKMuMu_l2Idx)")
-     .Define("m1_isTriggering_All", "Take(Muon_isTriggering, BToKMuMu_l1Idx)")
-     .Define("m2_isTriggering_All", "Take(Muon_isTriggering, BToKMuMu_l2Idx)")
+     .Define("m1_dz_All", "Take(Muon_dz, BToKMuMu_l1Idx)")
+     .Define("m2_dz_All", "Take(Muon_dz, BToKMuMu_l2Idx)")
+     .Define("m1_dzE_All", "Take(Muon_dzErr, BToKMuMu_l1Idx)")
+     .Define("m2_dzE_All", "Take(Muon_dzErr, BToKMuMu_l2Idx)")
+     .Define("m1_dxy_All", "Take(Muon_dxy, BToKMuMu_l1Idx)")
+     .Define("m2_dxy_All", "Take(Muon_dxy, BToKMuMu_l2Idx)")
+     .Define("m1_dxyE_All", "Take(Muon_dxyErr, BToKMuMu_l1Idx)")
+     .Define("m2_dxyE_All", "Take(Muon_dxyErr, BToKMuMu_l2Idx)")
+     .Define("m1_mvaID_All", "Take(Muon_mvaId, BToKMuMu_l1Idx)")
+     .Define("m2_mvaID_All", "Take(Muon_mvaId, BToKMuMu_l2Idx)")
+     .Define("m1_isPF_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Muon_isPFcand, BToKMuMu_l1Idx)")//bool
+     .Define("m2_isPF_All", "(ROOT::VecOps::RVec<unsigned int>) Take(Muon_isPFcand, BToKMuMu_l2Idx)")//bool
+     .Define("m1_isTriggering_All", "Take(Muon_isTriggering, BToKMuMu_l1Idx)")//int
+     .Define("m2_isTriggering_All", "Take(Muon_isTriggering, BToKMuMu_l2Idx)")//int
      .Define("KMM_nExtraTrg_All", "(nTriggerMuon - m1_isTriggering_All - m2_isTriggering_All)");
 
     std::cout << " totN start = " << *(d.Count())
@@ -399,24 +404,29 @@ inputFileList.push_back(base + "BuToKJpsi_ToMuMu_probefilter_SoftQCDnonD_TuneCP5
 				 "GenPart_l1_phi_GenAll", "GenPart_l2_phi_GenAll", "GenPart_k_phi_GenAll",
 				 "l1_phi_all", "l2_phi_all", "k_phi_all"})
                           .Define("rank_gendR_All", flagRank, {"n_Btriplet_all", "isGenMatched_All", "dRwithGen_All"});
+                          
+    auto mcGenMatched_i = mcGenMatched;
 
+    if(isEE)
+        mcGenMatched_i = mcGenMatched.Define("Idx_sel", si3sg, { "nBToKEE_All", "e1_isPFoverlap_All", 
+                                             "e2_isPFoverlap_All",  "KEE_fit_mass_All", "rank_gendR_All"} );
 
     //give eta, phi, l1, l2, k e gen
     std::cout << "\n computed dR for genmatched " << std::endl;
 
     if(outFName == "-1")
-      mcGenMatched.Snapshot("newtree", Form("output_RDF_Kll_isMC%d_isEE%d_BDT.root", isMC, isEE), "\\b([^ ]*)(_All)");
+      mcGenMatched_i.Snapshot("newtree", Form("output_RDF_Kll_isMC%d_isEE%d_BDT.root", isMC, isEE), "\\b([^ ]*)(_All)|\\b([^ ]*)(_sel)");
     else 
-      mcGenMatched.Snapshot("newtree", outFName.c_str(), "\\b([^ ]*)(_All)");
+      mcGenMatched_i.Snapshot("newtree", outFName.c_str(), "\\b([^ ]*)(_All)|\\b([^ ]*)(_sel)");
     //all triplets with Mc gen matched info
 
   }//isMC
   else{
 
     if(outFName == "-1")
-      tree_All.Snapshot("newtree", Form("output_RDF_Kll_isMC%d_BDT.root", isMC), "\\b([^ ]*)(_All)");
+      tree_All.Snapshot("newtree", Form("output_RDF_Kll_isMC%d_BDT.root", isMC), "\\b([^ ]*)(_All)|\\b([^ ]*)(_sel)");
     else
-      tree_All.Snapshot("newtree", outFName.c_str(), "\\b([^ ]*)(_All)");
+      tree_All.Snapshot("newtree", outFName.c_str(), "\\b([^ ]*)(_All)|\\b([^ ]*)(_sel)");
   }
 
   

--- a/RDFAnalysis/histTreeProducer_Kll.cpp
+++ b/RDFAnalysis/histTreeProducer_Kll.cpp
@@ -1,0 +1,266 @@
+/*
+----------------
+g++ -Wall -o histTreeProducer_Kll `root-config --cflags --glibs ` histTreeProducer_Kll.cpp
+----------------
+./histTreeProducer_Kll --JOBid (-1,1,2...) --inList nanoAOD_list.txt --outFile /path/to/output_file.root --isMC (0,1) --isEE (0,1) --isResonant (0,1) --testFile /path/to/input_file.root
+----------------
+Add --tree 1 to store the output as tree
+*/
+
+#include <ROOT/RDF/RInterface.hxx>
+#include <ROOT/RDF/InterfaceUtils.hxx>
+#include <ROOT/RDataFrame.hxx>
+#include <ROOT/RVec.hxx>
+
+#include <iostream>
+#include <fstream>
+#include <cstdio>
+#include <cstdlib>
+
+#include "TStopwatch.h"
+#include <vector>
+#include <string>
+//#include <regex>
+
+#include "interface/functions.h"
+//using namespace ROOT::VecOps;
+
+
+int main(int argc, char **argv){
+
+  TStopwatch t;
+  t.Start();
+
+  if(argc < 2) {
+    std::cout << " Missing arguments " << std::endl;
+    return -1;
+  }
+
+  std::string JOBid = "-1";
+  std::string inList = "-1";
+  std::string outFName = "-1";
+  int isMC = 0;
+  int isEE = 0;
+  int isResonant = 0;
+  int isTree = 0;
+  std::string testFile = "-1";
+
+  parseInputs(argc, argv, JOBid, inList, outFName, isMC, isEE, isResonant, testFile);
+
+  for (int i = 1; i < argc; ++i) {
+    if(std::string(argv[i]) == "--tree") {
+      if (i + 1 < argc) {
+	isTree = atoi(argv[i+1]);
+	break;
+      }
+      else {
+	std::cerr << " --tree option requires one argument " << std::endl;
+	return 1;
+      }
+    }
+  }
+
+  if(inList != "-1" && JOBid == "-1"){
+    std::cout << " running a test => careful: splitting file based but missing JOBid and output file path " << std::endl;
+  }
+
+  if(inList == "-1" && testFile == "-1"){
+    std::cout << " by default " << std::endl;
+  }
+
+  std::cout << " inList = " << inList << " JOBid = " << JOBid << " outFName = " << outFName << " testFile = " << testFile
+	    << " isMC = " << isMC << " isEE = " << isEE << " isResonant = " << isResonant << "\n" << std::endl;
+
+  std::vector<std::string> inputFileList;
+  
+  if(inList != "-1"){
+    std::string rootFileName;
+    std::ifstream inFileLong;
+    inFileLong.open(inList.c_str(), std::ios::in);
+    while(!inFileLong.eof()){
+      inFileLong >> rootFileName;
+      if( inFileLong.eof() ) break;
+      inputFileList.push_back(rootFileName);
+    }
+  }
+  else if(testFile != "-1"){
+    inputFileList.push_back(testFile);
+  }
+  else{
+    if(isMC){
+    std::string base = "/vols/cms/vc1116/BParking/BDT_variables/";
+	if(isEE) 
+inputFileList.push_back(base + "tree_BParkingNANO_2019Oct25_MC_BuToKee/*_1.root");
+	else 
+inputFileList.push_back(base + "");
+    }
+    else{
+    std::string base = "/vols/cms/vc1116/BParking/BDT_variables/";
+    inputFileList.push_back(base + "tree_BParkingNANO_2019Oct21_Run2018A_part2/*_1.root");
+    }
+  }//defaut
+ 
+  inList = "-1";
+  for(auto ij : inputFileList) std::cout << " file = " << ij << std::endl;
+ 
+  ROOT::RDataFrame d("newtree", inputFileList);
+ 
+  
+  auto n = d.Define("lumi_all", "lumi_All")
+    .Define("eventToT_all", "eventToT_All")
+    .Define("run_all", "run_All")
+    .Define("KEE_fit_mass_sel", "Take(KEE_fit_mass_All, Idx_sel)")
+    .Define("KEE_fit_massErr_sel", "Take(KEE_fit_massErr_All, Idx_sel)")
+    .Define("KEE_cos2D_sel", "Take(KEE_cos2D_All, Idx_sel)")
+    .Define("KEE_vtxProb_sel", "Take(KEE_vtxProb_All, Idx_sel)")
+    .Define("KEE_l_xy_unc_sel", "Take(KEE_l_xy_unc_All, Idx_sel)")
+    .Define("KEE_l_xyS_sel", "Take(KEE_l_xyS_All, Idx_sel)")
+    .Define("KEE_pT_sel", "Take(KEE_pT_All, Idx_sel)")
+    .Define("KEE_eta_sel", "Take(KEE_eta_All, Idx_sel)")
+    .Define("KEE_phi_sel",  "Take(KEE_phi_All, Idx_sel)")
+    .Define("KEE_mll_fullfit_sel", "Take(KEE_mll_fullfit_All, Idx_sel)")
+    .Define("KEE_k_eta_sel", "Take(KEE_k_eta_All, Idx_sel)")
+    .Define("KEE_k_phi_sel", "Take(KEE_k_phi_All, Idx_sel)")
+    .Define("KEE_k_pt_sel",  "Take(KEE_k_pt_All, Idx_sel)")
+    .Define("KEE_k_dz_sel", "Take(KEE_k_dz_All, Idx_sel)")
+    .Define("KEE_k_dzE_sel", "Take(KEE_k_dzE_All, Idx_sel)")
+    .Define("KEE_k_dxy_sel", "Take(KEE_k_dxy_All, Idx_sel)")
+    .Define("KEE_k_dxyE_sel", "Take(KEE_k_dxyE_All, Idx_sel)")
+    .Define("KEE_k_isPck_sel", "Take(KEE_k_isPck_All, Idx_sel)")
+    .Define("e1_eta_sel", "Take(e1_eta_All, Idx_sel)")
+    .Define("e2_eta_sel", "Take(e2_eta_All, Idx_sel)")
+    .Define("e1_phi_sel", "Take(e1_phi_All, Idx_sel)")
+    .Define("e2_phi_sel", "Take(e2_phi_All, Idx_sel)")
+    .Define("e1_pt_sel", "Take(e1_pt_All, Idx_sel)")
+    .Define("e2_pt_sel", "Take(e2_pt_All, Idx_sel)")
+    .Define("e1_dz_sel", "Take(e1_dz_All, Idx_sel)")
+    .Define("e2_dz_sel", "Take(e2_dz_All, Idx_sel)")
+    .Define("e1_dzE_sel", "Take(e1_dzE_All, Idx_sel)")
+    .Define("e2_dzE_sel", "Take(e2_dzE_All, Idx_sel)")
+    .Define("e1_dxy_sel", "Take(e1_dxy_All, Idx_sel)")
+    .Define("e2_dxy_sel", "Take(e2_dxy_All, Idx_sel)")
+    .Define("e1_dxyE_sel", "Take(e1_dxyE_All, Idx_sel)")
+    .Define("e2_dxyE_sel", "Take(e2_dxyE_All, Idx_sel)")
+    .Define("e1_isConvVeto_sel", "Take(e1_isConvVeto_All, Idx_sel)")
+    .Define("e2_isConvVeto_sel", "Take(e2_isConvVeto_All, Idx_sel)")
+    .Define("e1_seedID_sel", "Take(e1_seedID_All, Idx_sel)")
+    .Define("e2_seedID_sel", "Take(e2_seedID_All, Idx_sel)")
+    .Define("e1_mvaID_sel", "Take(e1_mvaID_All, Idx_sel)")
+    .Define("e2_mvaID_sel", "Take(e2_mvaID_All, Idx_sel)")
+    .Define("e1_isPF_sel", "Take(e1_isPF_All, Idx_sel)")
+    .Define("e2_isPF_sel", "Take(e2_isPF_All, Idx_sel)")
+    .Define("e1_isLowPt_sel", "Take(e1_isLowPt_All, Idx_sel)")
+    .Define("e2_isLowPt_sel", "Take(e2_isLowPt_All, Idx_sel)");
+  
+ 
+  if(!isTree){
+    auto h_KEE_fit_mass = n.Histo1D( {"KEE_fit_mass", "", 75, 4.5, 6.0}, "KEE_fit_mass_sel");
+    auto h_KEE_fit_massErr = n.Histo1D( {"KEE_fit_massErr", "", 50, 0., 1.}, "KEE_fit_massErr_sel");
+    auto h_KEE_cos2D = n.Histo1D( {"KEE_cos2D", "", 60, -0.1, 1.1}, "KEE_cos2D_sel");
+    auto h_KEE_vtxProb = n.Histo1D( {"KEE_vtxProb", "", 50, 0., 1.}, "KEE_vtxProb_sel");
+    auto h_KEE_l_xy_unc = n.Histo1D( {"KEE_l_xy_unc", "", 30, 0., 0.6}, "KEE_l_xy_unc_sel");
+    auto h_KEE_l_xyS = n.Histo1D( {"KEE_l_xyS", "", 700, 0., 70.}, "KEE_l_xyS_sel");
+    auto h_KEE_pT = n.Histo1D( {"KEE_pT", "", 700, 0., 70.}, "KEE_pT_sel"); 
+    auto h_KEE_eta = n.Histo1D( {"KEE_eta", "", 80, -4., 4.}, "KEE_eta_sel");   
+    auto h_KEE_phi = n.Histo1D( {"KEE_phi", "", 80, -4., 4.}, "KEE_phi_sel");  
+    auto h_KEE_mll_fullfit = n.Histo1D( {"KEE_mll_fullfit", "", 300, 0., 6.}, "KEE_mll_fullfit_sel");   
+    auto h_KEE_k_eta = n.Histo1D( {"KEE_k_eta", "", 60, -3., 3.}, "KEE_k_eta_sel"); 
+    auto h_KEE_k_phi = n.Histo1D( {"KEE_k_phi", "", 80, -4., 4.}, "KEE_k_phi_sel");   
+    auto h_KEE_k_pt = n.Histo1D( {"KEE_k_pt", "", 250, 0., 25.}, "KEE_k_pt_sel");  
+    auto h_KEE_k_dz = n.Histo1D( {"KEE_k_dz", "", 300, -15., 15.}, "KEE_k_dz_sel");   
+    auto h_KEE_k_dzE = n.Histo1D( {"KEE_k_dzE", "", 400, -2000., 2000.}, "KEE_k_dzE_sel");  
+    auto h_KEE_k_dxy = n.Histo1D( {"KEE_k_dxy", "", 20, -1., 1.}, "KEE_k_dxy_sel");  
+    auto h_KEE_k_dxyE = n.Histo1D( {"KEE_k_dxyE", "", 800, -40., 40.}, "KEE_k_dxyE_sel");  
+    auto h_KEE_k_isPck = n.Histo1D( {"KEE_k_isPck", "", 2, 0., 2.}, "KEE_k_isPck_sel");
+    auto h_e1_eta = n.Histo1D( {"e1_eta", "", 60, -3., 3.}, "e1_eta_sel");  
+    auto h_e2_eta = n.Histo1D( {"e2_eta", "", 60, -3., 3.}, "e2_eta_sel");  
+    auto h_e1_phi = n.Histo1D( {"e1_phi", "", 80, -4., 4.}, "e1_phi_sel");  
+    auto h_e2_phi = n.Histo1D( {"e2_phi", "", 80, -4., 4.}, "e2_phi_sel");  
+    auto h_e1_pt = n.Histo1D( {"e1_pt", "", 400, 0., 40.}, "e1_pt_sel");
+    auto h_e2_pt = n.Histo1D( {"e2_pt", "", 250, 0., 25.}, "e2_pt_sel");  
+    auto h_e1_dz = n.Histo1D( {"e1_dz", "", 300, -15., 15.}, "e1_dz_sel");  
+    auto h_e2_dz = n.Histo1D( {"e2_dz", "", 300, -15., 15.}, "e2_dz_sel");  
+    auto h_e1_dzE = n.Histo1D( {"e1_dzE", "", 50, 0., 5.}, "e1_dzE_sel");  
+    auto h_e2_dzE = n.Histo1D( {"e2_dzE", "", 40, 0., 4.}, "e2_dzE_sel");  
+    auto h_e1_dxy = n.Histo1D( {"e1_dxy", "", 100, -5., 5.}, "e1_dxy_sel");   
+    auto h_e2_dxy = n.Histo1D( {"e2_dxy", "", 180, -9., 9.}, "e2_dxy_sel");  
+    auto h_e1_dxyE = n.Histo1D( {"e1_dxyE", "", 40, 0., 4.}, "e1_dxyE_sel");  
+    auto h_e2_dxyE = n.Histo1D( {"e2_dxyE", "", 80, 0., 8.}, "e2_dxyE_sel");
+    auto h_e1_isConvVeto = n.Histo1D( {"e1_isConvVeto", "", 2, 0., 2.}, "e1_isConvVeto_sel");  
+    auto h_e2_isConvVeto = n.Histo1D( {"e2_isConvVeto", "", 2, 0., 2.}, "e2_isConvVeto_sel");  
+    auto h_e1_seedID = n.Histo1D( {"e1_seedID", "", 150, 0., 15.}, "e1_seedID_sel");  
+    auto h_e2_seedID = n.Histo1D( {"e2_seedID", "", 200, -5., 15.}, "e2_seedID_sel");  
+    auto h_e1_mvaID = n.Histo1D( {"e1_mvaID", "", 200, -10., 10.}, "e1_mvaID_sel");  
+    auto h_e2_mvaID = n.Histo1D( {"e2_mvaID", "", 200, -10., 10.}, "e2_mvaID_sel");
+    auto h_e1_isPF = n.Histo1D( {"e1_isPF", "", 2, 0., 2.}, "e1_isPF_sel");  
+    auto h_e2_isPF = n.Histo1D( {"e2_isPF", "", 2, 0., 2.}, "e2_isPF_sel");  
+    auto h_e1_isLowPt = n.Histo1D( {"e1_isLowPt", "", 2, 0., 2.}, "e1_isLowPt_sel");  
+    auto h_e2_isLowPt = n.Histo1D( {"e2_isLowPt", "", 2, 0., 2.}, "e2_isLowPt_sel");
+  
+    std::string outName = Form("histos_RDF_Kll_isMC%d_isEE%d.root", isMC, isEE);
+    if(outFName != "-1") outName = outFName;  
+  
+    TFile outHistos(outName.c_str(), "recreate");
+
+    outHistos.cd();
+
+    h_KEE_fit_mass->Write();
+    h_KEE_fit_massErr->Write();
+    h_KEE_cos2D->Write();
+    h_KEE_vtxProb->Write();
+    h_KEE_l_xy_unc->Write();
+    h_KEE_l_xyS->Write();  
+    h_KEE_pT->Write();
+    h_KEE_eta->Write();
+    h_KEE_phi->Write();
+    h_KEE_mll_fullfit->Write();
+    h_KEE_k_eta->Write();  
+    h_KEE_k_phi->Write();  
+    h_KEE_k_pt->Write();
+    h_KEE_k_dz->Write();  
+    h_KEE_k_dzE->Write();
+    h_KEE_k_dxy->Write();
+    h_KEE_k_dxyE->Write();
+    h_KEE_k_isPck->Write();
+    h_e1_eta->Write();  
+    h_e2_eta->Write();  
+    h_e1_phi->Write();  
+    h_e2_phi->Write();
+    h_e1_pt->Write();  
+    h_e2_pt->Write();
+    h_e1_dz->Write();  
+    h_e2_dz->Write();  
+    h_e1_dzE->Write();  
+    h_e2_dzE->Write();
+    h_e1_dxy->Write();  
+    h_e2_dxy->Write();  
+    h_e1_dxyE->Write();  
+    h_e2_dxyE->Write();
+    h_e1_isConvVeto->Write();  
+    h_e2_isConvVeto->Write();
+    h_e1_seedID->Write();  
+    h_e2_seedID->Write();
+    h_e1_mvaID->Write();  
+    h_e2_mvaID->Write();
+    h_e1_isPF->Write();  
+    h_e2_isPF->Write();
+    h_e1_isLowPt->Write();   
+    h_e2_isLowPt->Write();  
+  
+    outHistos.Close();
+
+  }
+  else{
+
+    if(outFName == "-1")
+      n.Snapshot("selTree", Form("tree_RDF_Kll_isMC%d_isEE%d.root", isMC, isEE), "\\b([^ ]*)(_sel)|\\b([^ ]*)(_all)");
+    else
+      n.Snapshot("selTree", outFName.c_str(), "\\b([^ ]*)(_sel)|\\b([^ ]*)(_all)");
+
+  }
+  
+  t.Stop(); 
+  t.Print();
+
+}  
+ 

--- a/RDFAnalysis/interface/functions.h
+++ b/RDFAnalysis/interface/functions.h
@@ -167,6 +167,41 @@ ROOT::VecOps::RVec<int> KMMcut(unsigned int nB,
 }
 
 
+// Bkg SB regions
+ROOT::VecOps::RVec<unsigned int> bkgSB(unsigned int nB,
+				       ROOT::VecOps::RVec<unsigned int>& e1isPFover,
+				       ROOT::VecOps::RVec<unsigned int>& e2isPFover,
+				       ROOT::VecOps::RVec<float>& B_fit_mass){
+
+  ROOT::VecOps::RVec<unsigned int> out_idx;
+  for (unsigned int ij=0; ij<nB; ++ij){
+    if( (e1isPFover[ij] == 0 && e2isPFover[ij] == 0) &&
+        ( (B_fit_mass[ij] > 4.8947 && B_fit_mass[ij] < 5.0807) || 
+          (B_fit_mass[ij] > 5.4527 && B_fit_mass[ij] < 5.6387) ) 
+      )out_idx.push_back(ij);
+  }
+  return out_idx;
+}
+
+
+// Sig 3sigma region
+ROOT::VecOps::RVec<unsigned int> si3sg(unsigned int nB,
+				       ROOT::VecOps::RVec<unsigned int>& e1isPFover,
+				       ROOT::VecOps::RVec<unsigned int>& e2isPFover,
+				       ROOT::VecOps::RVec<float>& B_fit_mass,
+				       ROOT::VecOps::RVec<int>& rank){
+
+  ROOT::VecOps::RVec<unsigned int> out_idx;
+  for (unsigned int ij=0; ij<nB; ++ij){
+    if( (e1isPFover[ij] == 0 && e2isPFover[ij] == 0) &&
+        (B_fit_mass[ij] > 5.0807 && B_fit_mass[ij] < 5.4527) &&
+	rank[ij] == 0
+      )out_idx.push_back(ij);
+  }
+  return out_idx;
+}
+
+
 //FilterGood
 ROOT::VecOps::RVec<unsigned int> selectGoodIdx(ROOT::VecOps::RVec<int>& goodIdxs){
 

--- a/RDFAnalysis/macro/NormHist.cc
+++ b/RDFAnalysis/macro/NormHist.cc
@@ -1,0 +1,30 @@
+/*
+A macro to normalize and save to a file all histograms from an input file
+root NormHist.cc'("/vols/cms/vc1116/BParking/BDT_variables/SB_HIST_BParkingNANO_2019Oct21_Run2018A_part2.root")'
+https://root.cern.ch/doc/master/loopdir11_8C.html
+*/
+
+void NormHist(std::string inFile) {
+   
+   TFile* inF = TFile::Open(inFile.c_str());
+   
+   std::string outFile = inFile;
+   outFile = std::regex_replace(outFile, std::regex("\\.root"), "_NORM.root");
+   
+   TFile outF(outFile.c_str(), "recreate");
+   outF.cd();
+   
+   for(auto k : *inF->GetListOfKeys()) {
+      TKey *key = static_cast<TKey*>(k);
+      TClass *cl = gROOT->GetClass(key->GetClassName());
+      if (!cl->InheritsFrom("TH1")) continue;
+      TH1 *h = key->ReadObject<TH1>();
+      double_t scale = 1/h->Integral();
+      h->Scale(scale);
+      h->SetOption("HIST"); 
+      h->Write();
+   }
+   
+   outF.Close();
+
+}


### PR DESCRIPTION
- Add indices to determine signal ( [mu - 3 x sig, mu + 3 x sig] ) and sideband ( [mu - 6 x sig, mu - 3 x sig] U [mu + 3 x sig, mu + 6 x sig] ) regions for no-PF-overlapped electrons, with mu = 5.2667 and sig = 0.062

-  Cleaning

-  Upload new macro to reconstruct variables in signal or sideband regions, storing the output as histograms or tree